### PR TITLE
Prevent more icon from wraparound

### DIFF
--- a/src/less/components/userbadge.less
+++ b/src/less/components/userbadge.less
@@ -36,7 +36,6 @@
     margin-left: -100%;
   }
   .right-cell {
-    width: 1.6875em;
     margin-left: -1.75em;
   }
 


### PR DESCRIPTION
Higher screen pixel widths do not handle current setting well. As the more icon is the right-most element, it does not need a hard width value. When it has a hard value it becomes too wide and wraps to a lower screen position. My screen resolution is reporting 1707 pixels on Passbolt container element width.

Without Fix on custom screen scaled Firefox:
![image](https://user-images.githubusercontent.com/47018474/132095956-f9785de3-4592-4ffd-8327-daa4f3eb2a0e.png)


To reproduce on Chrome, scale screen smaller with `Ctrl -`. At 1366 screen width it's fine, but at 90% which result in 1517 pixel width, it wraps around.