### PR TITLE
Show absolute dates as dates' tooltips

### DIFF
--- a/src/react-extension/components/ResourceDetails/DisplayResourceDetails/DisplayResourceDetailsInformation.js
+++ b/src/react-extension/components/ResourceDetails/DisplayResourceDetails/DisplayResourceDetailsInformation.js
@@ -387,7 +387,7 @@ class DisplayResourceDetailsInformation extends React.Component {
           </li>
           <li className="modified">
             <span className="label"><Trans>Modified</Trans></span>
-            <span className="value">{modifiedDateTimeAgo}</span>
+            <span className="value" title={this.resource.modified}>{modifiedDateTimeAgo}</span>
           </li>
           <li className="modified-by">
             <span className="label"><Trans>Modified by</Trans></span>
@@ -395,7 +395,7 @@ class DisplayResourceDetailsInformation extends React.Component {
           </li>
           <li className="modified">
             <span className="label"><Trans>Created</Trans></span>
-            <span className="value">{createdDateTimeAgo}</span>
+            <span className="value" title={this.resource.created}>{createdDateTimeAgo}</span>
           </li>
           <li className="modified-by">
             <span className="label"><Trans>Created by</Trans></span>

--- a/src/react-extension/components/ResourceDetails/DisplayResourceDetails/DisplayResourceDetailsInformation.test.js
+++ b/src/react-extension/components/ResourceDetails/DisplayResourceDetails/DisplayResourceDetailsInformation.test.js
@@ -56,9 +56,11 @@ describe("See information", () => {
       page = new DisplayResourceDetailsInformationPage(context, props);
       await waitFor(() => {});
 
-      const modificationDate = DateTime.fromISO(props.resourceWorkspaceContext.details.resource.modified).toRelative();
-      const creationDate = DateTime.fromISO(props.resourceWorkspaceContext.details.resource.created).toRelative();
-      expect.assertions(16);
+      const absoluteModificationDate = props.resourceWorkspaceContext.details.resource.modified;
+      const modificationDate = DateTime.fromISO(absoluteModificationDate).toRelative();
+      const absoluteCreationDate = props.resourceWorkspaceContext.details.resource.created;
+      const creationDate = DateTime.fromISO(absoluteCreationDate).toRelative();
+      expect.assertions(18);
       expect(page.displayInformationList.usernameLabel).toBe('Username');
       expect(page.displayInformationList.username.textContent).toBe(props.resourceWorkspaceContext.details.resource.username);
       expect(page.displayInformationList.passwordLabel).toBe('Password');
@@ -67,10 +69,12 @@ describe("See information", () => {
       expect(page.displayInformationList.uri.textContent).toBe(props.resourceWorkspaceContext.details.resource.uri);
       expect(page.displayInformationList.modifiedLabel(1)).toBe('Modified');
       expect(page.displayInformationList.modified(1).textContent).toBe(modificationDate);
+      expect(page.displayInformationList.modified(1).getAttribute("title")).toBe(absoluteModificationDate);
       expect(page.displayInformationList.modifiedByLabel(1)).toBe('Modified by');
       expect(page.displayInformationList.modifiedBy(1).textContent).toBe('ada@passbolt.com');
       expect(page.displayInformationList.modifiedLabel(2)).toBe('Created');
       expect(page.displayInformationList.modified(2).textContent).toBe(creationDate);
+      expect(page.displayInformationList.modified(2).getAttribute("title")).toBe(absoluteCreationDate);
       expect(page.displayInformationList.modifiedByLabel(2)).toBe('Created by');
       expect(page.displayInformationList.modifiedBy(2).textContent).toBe('ada@passbolt.com');
       expect(page.displayInformationList.locationLabel).toBe('Location');

--- a/src/react-extension/components/ResourceFolderDetails/DisplayResourceFolderDetails/DisplayResourceFolderDetailsInformation.js
+++ b/src/react-extension/components/ResourceFolderDetails/DisplayResourceFolderDetails/DisplayResourceFolderDetailsInformation.js
@@ -163,7 +163,7 @@ class DisplayResourceFolderDetailsInformation extends React.Component {
             </li>
             <li className="modified">
               <span className="label"><Trans>Modified</Trans></span>
-              <span className="value">{modifiedDateTimeAgo}</span>
+              <span className="value" title={this.folder.modified}>{modifiedDateTimeAgo}</span>
             </li>
             <li className="modified-by">
               <span className="label"><Trans>Modified by</Trans></span>
@@ -171,7 +171,7 @@ class DisplayResourceFolderDetailsInformation extends React.Component {
             </li>
             <li className="modified">
               <span className="label"><Trans>Created</Trans></span>
-              <span className="value">{createdDateTimeAgo}</span>
+              <span className="value" title={this.folder.created}>{createdDateTimeAgo}</span>
             </li>
             <li className="modified-by">
               <span className="label"><Trans>Created by</Trans></span>

--- a/src/react-extension/components/ResourceFolderDetails/DisplayResourceFolderDetails/DisplayResourceFolderDetailsInformation.test.js
+++ b/src/react-extension/components/ResourceFolderDetails/DisplayResourceFolderDetails/DisplayResourceFolderDetailsInformation.test.js
@@ -57,16 +57,17 @@ describe("See information", () => {
     it('I should be able to identify each information name', async() => {
       mockContextRequest(copyClipboardMockImpl);
       jest.spyOn(ActionFeedbackContext._currentValue, 'displaySuccess').mockImplementation(() => {});
-
-      expect.assertions(12);
+      expect.assertions(14);
       expect(page.displayInformationList.usernameLabel).toBe('Name');
       expect(page.displayInformationList.username.textContent).toBe(props.resourceWorkspaceContext.details.folder.name);
       expect(page.displayInformationList.modifiedLabel(1)).toBe('Modified');
       expect(page.displayInformationList.modified(1).textContent).toContain('ago');
+      expect(page.displayInformationList.modified(1).getAttribute("title")).toBe('2020-02-01T00:00:00+00:00');
       expect(page.displayInformationList.modifiedByLabel(1)).toBe('Modified by');
       expect(page.displayInformationList.modifiedBy(1).textContent).toBe('ada@passbolt.com');
       expect(page.displayInformationList.modifiedLabel(2)).toBe('Created');
       expect(page.displayInformationList.modified(2).textContent).toContain('ago');
+      expect(page.displayInformationList.modified(2).getAttribute("title")).toBe('2020-02-01T00:00:00+00:00');
       expect(page.displayInformationList.modifiedByLabel(2)).toBe('Created by');
       expect(page.displayInformationList.modifiedBy(2).textContent).toBe('ada@passbolt.com');
       expect(page.displayInformationList.locationLabel).toBe('Location');

--- a/src/react-extension/components/UserGroup/DisplayUserGroupDetailsInformation/DisplayUserGroupDetailsInformation.js
+++ b/src/react-extension/components/UserGroup/DisplayUserGroupDetailsInformation/DisplayUserGroupDetailsInformation.js
@@ -107,11 +107,11 @@ class DisplayUserGroupDetailsInformation extends React.Component {
           <ul>
             <li className="created">
               <span className="label"><Trans>Created</Trans></span>
-              <span className="value">{created}</span>
+              <span className="value" title={this.group.created}>{created}</span>
             </li>
             <li className="modified">
               <span className="label"><Trans>Modified</Trans></span>
-              <span className="value">{modified}</span>
+              <span className="value" title={this.group.modified}>{modified}</span>
             </li>
             <li className="modified-by">
               <span className="label"><Trans>Modified by</Trans></span>


### PR DESCRIPTION
Whenever we show creation or modification dates in a relative format, add a tooltip with the absolute date to provide the full, exact information.

See [this forum thread](https://community.passbolt.com/t/as-a-user-i-want-to-see-the-absolute-dates-of-the-relative-dates-i-currently-see/5459/3) for context. This is the easiest possible implementation, since I was not able to see the results.

⚠️ I was not able to try the changes (there doesn't seem to be a demo page for this, and it's a bit out of my league to try and create one for now). And I do not know how to build a development version of the plugin or similar. But the code seems kind of OK.

I've also tried respecting the coding style of each of the components I was modifying.

The tests run, but I did not add any test to one of the screens since there were none to begin with (again, probably out of my league to go there).

Please do let me know if there's anything I've missed, or if there's a kind-of-easy way to test this - I may try going for the copy to clipboard version if I was able to test the thing.

---

I hope you know "Thanks for making Passbolt" is written as a subtext of every byte spilled here, but just in case - thanks for making Passbolt!