### PR TITLE
better sorting results and favorites on top

### DIFF
--- a/src/react-web-integration/components/DisplayInFormMenu/DisplayInFormMenu.js
+++ b/src/react-web-integration/components/DisplayInFormMenu/DisplayInFormMenu.js
@@ -314,6 +314,24 @@ class DisplayInFormMenu extends React.Component {
    */
   async handleDisplayConfigurationReceivedEvent() {
     const configuration = await this.props.context.port.request('passbolt.in-form-menu.init');
+
+    // Sort suggested resources: favorites first, then alphabetically
+    if (configuration?.suggestedResources?.length > 0) {
+      configuration.suggestedResources.sort((a, b) => {
+        // Priority 1: Favorites first
+        const aIsFavorite = a.favorite !== null;
+        const bIsFavorite = b.favorite !== null;
+        if (aIsFavorite !== bIsFavorite) {
+          return aIsFavorite ? -1 : 1;
+        }
+
+        // Priority 2: Sort alphabetically by name
+        const aName = a.metadata.name.toUpperCase();
+        const bName = b.metadata.name.toUpperCase();
+        return aName.localeCompare(bName);
+      });
+    }
+
     this.setState({configuration});
     if (!this.isPasswordFilled) {
       // Pre-generate the password


### PR DESCRIPTION
We have multiple passwords for the same user on different websites.. and for the same website we can have more then 100 users.

When in the page i would search on the quick access and would have to scroll trough all the passwords with that user name and find the one corresponding to the site i was already in. With this change,.. current site passwords appear on top.

Also, half of the time, for a specific site i would use (for example) 5 passwords.. with this change, i can mark them has favorites and they will appear on top

