### PR TITLE
Add selector for 'benutzer' in username field detection

### DIFF
--- a/src/react-web-integration/lib/InForm/InFormFieldSelector.js
+++ b/src/react-web-integration/lib/InForm/InFormFieldSelector.js
@@ -23,6 +23,7 @@ export default {
    * The selector create-account-input is for ovh.com website
    * The selector benutzerkennung is for german website
    * The selector benutzername is also for somes german websites
+   * The selector benutzer is also for somes german websites
    * The selector utilisateur is for french website
    */
   USERNAME_FIELD_SELECTOR: `${Object.values(UsernameFieldSelectorException).join(",")},
@@ -39,6 +40,7 @@ export default {
   input[type='text' i][id*='logto' i]:not([hidden]):not([disabled]),
   input[type='text' i][id*='benutzerkennung' i]:not([hidden]):not([disabled]),
   input[type='text' i][id*='benutzername' i]:not([hidden]):not([disabled]),
+  input[type='text' i][id*='benutzer' i]:not([hidden]):not([disabled]),
   input[type='text' i][id*='utilisateur' i]:not([hidden]):not([disabled]),
   input[type='text' i][class*='user' i]:not([hidden]):not([disabled]),
   input[type='text' i][class*='email' i]:not([hidden]):not([disabled]),


### PR DESCRIPTION
Sometimes german websites use the translation of user "Benutzer" for an username input field.
Including a site I have to login multiple times per workday.

I followed the style of previous comments, but maybe they should be consolidated.