### PR TITLE
feat(quickaccess): launch control + keyboard navigation in search results

### DIFF
--- a/src/less/page-components/quickaccess/quickaccess_list.less
+++ b/src/less/page-components/quickaccess/quickaccess_list.less
@@ -7,6 +7,20 @@
             scrollbar-width: thin;
             scrollbar-color: var(--Workspace-Elevator) transparent;
         }
+        /* Visible keyboard-focus indicator for list rows (suggested, browse, filters, launch). */
+        .resource-details,
+        .chevron-right-wrapper,
+        .launch-resource-button,
+        .browse-resource-entry > a,
+        .filter-entry > a {
+            /* !important so the focus ring wins over each control's base inset box-shadow (divider). */
+            &:focus-visible {
+                box-shadow: 0 0 .4rem var(--States-Focus), inset 0 0 0 .1rem var(--States-Focus) !important;
+                outline: none;
+                position: relative;
+                z-index: 1;
+            }
+        }
         .list-title {
             background: var(--Quick-Access-Header-and-footer-background);
         }

--- a/src/less/page-components/quickaccess/quickaccess_list.less
+++ b/src/less/page-components/quickaccess/quickaccess_list.less
@@ -108,7 +108,12 @@
         }
 
         .browse-resource-entry {
+          display: flex;
+          align-items: stretch;
+
           a {
+            flex: 1 1 auto;
+            min-width: 0;
             .inline-resource-entry {
               flex: 1 1 auto;
               width: 80%;
@@ -136,6 +141,23 @@
                   margin-top: .2rem;
                 }
               }
+            }
+          }
+
+          .launch-resource-button {
+            flex: 0 0 auto;
+            display: flex;
+            align-items: center;
+            padding: 0 1.6rem;
+            border: none;
+            background: transparent;
+            cursor: pointer;
+            color: var(--Text-and-icons-Secondary-text);
+            box-shadow: inset 0 -.1rem 0 var(--Workspace-Dividers);
+
+            &:hover {
+              background: var(--Quick-Access-Filter-hover);
+              color: var(--Text-and-icons-Main-text);
             }
           }
         }

--- a/src/react-quickaccess/components/HomePage/HomePage.js
+++ b/src/react-quickaccess/components/HomePage/HomePage.js
@@ -117,6 +117,7 @@ class HomePage extends React.Component {
   initEventHandlers() {
     this.handleUseOnThisTabClick = this.handleUseOnThisTabClick.bind(this);
     this.handleLaunchResourceClick = this.handleLaunchResourceClick.bind(this);
+    this.handleOpenResourceClick = this.handleOpenResourceClick.bind(this);
     this.handleListKeyDown = this.handleListKeyDown.bind(this);
   }
 
@@ -157,6 +158,28 @@ class HomePage extends React.Component {
     // Fire-and-forget: do not await; the controller continues in the background after the popup closes.
     this.props.context.port
       .request("passbolt.quickaccess.launch-resource", resource.id, this.props.context.getOpenerTabId())
+      .catch((error) => console.error(error));
+    this.props.context.closeWindow();
+  }
+
+  /**
+   * Handles the click on a search-result row's launch action when autofill on launch is disabled.
+   * Opens the resource URI in a tab without decrypting or autofilling any secret. The background
+   * reuses the opener tab when it is blank (e.g. an incognito new-tab page), otherwise opens a new
+   * tab, matching the autofill-enabled behaviour. The popup is closed immediately.
+   * @param {Event} event
+   * @param {Object} resource
+   * @returns {void}
+   */
+  handleOpenResourceClick(event, resource) {
+    event.preventDefault();
+    const uri = resource.metadata?.uris?.[0];
+    if (!uri) {
+      return;
+    }
+    // Fire-and-forget: do not await; navigation continues in the background after the popup closes.
+    this.props.context.port
+      .request("passbolt.quickaccess.open-resource-uri", uri, this.props.context.getOpenerTabId())
       .catch((error) => console.error(error));
     this.props.context.closeWindow();
   }
@@ -525,19 +548,17 @@ class HomePage extends React.Component {
                               </span>
                             </button>
                           ) : (
-                            <a
-                              href={this.sanitizeResourceUrl(resource.metadata.uris?.[0])}
-                              role="button"
+                            <button
+                              type="button"
                               className="launch-resource-button"
-                              target="_blank"
-                              rel="noopener noreferrer"
+                              onClick={(event) => this.handleOpenResourceClick(event, resource)}
                               title={this.props.t("Open in a new tab")}
                             >
                               <GoSVG />
                               <span className="visually-hidden">
                                 <Trans>Open in a new tab</Trans>
                               </span>
-                            </a>
+                            </button>
                           ))}
                       </li>
                     ))}

--- a/src/react-quickaccess/components/HomePage/HomePage.js
+++ b/src/react-quickaccess/components/HomePage/HomePage.js
@@ -34,6 +34,7 @@ import {
 import DisplayResourceUrisBadge from "../../../react-extension/components/Resource/DisplayResourceUrisBadge/DisplayResourceUrisBadge";
 import CanSuggestService from "../../../shared/services/canSuggestService/canSuggestService";
 import CaretRightSVG from "../../../img/svg/caret_right.svg";
+import GoSVG from "../../../img/svg/go.svg";
 import FilterSVG from "../../../img/svg/filter.svg";
 import UsersSVG from "../../../img/svg/users.svg";
 import TagV2SVG from "../../../img/svg/tag_v2.svg";
@@ -100,6 +101,7 @@ class HomePage extends React.Component {
    */
   initEventHandlers() {
     this.handleUseOnThisTabClick = this.handleUseOnThisTabClick.bind(this);
+    this.handleLaunchResourceClick = this.handleLaunchResourceClick.bind(this);
   }
 
   /**
@@ -187,6 +189,32 @@ class HomePage extends React.Component {
           ),
         });
       }
+    }
+  }
+
+  /**
+   * Handles the click on a search-result row's "open in a new tab" action.
+   * Navigates a new browser tab to the resource's stored URI without decrypting
+   * or autofilling any secret. The background controller sanitises the URI.
+   * @param {Event} event
+   * @param {Object} resource
+   * @returns {Promise<void>}
+   */
+  async handleLaunchResourceClick(event, resource) {
+    // The button is a sibling of the row link; prevent the row navigation.
+    event.preventDefault();
+    event.stopPropagation();
+
+    const uri = resource.metadata?.uris?.[0];
+    if (!uri) {
+      return;
+    }
+
+    try {
+      await this.props.context.port.request("passbolt.tabs.open-resource-uri", uri);
+      await this.props.context.closeWindow();
+    } catch (error) {
+      console.error("Unable to open the resource URL in a new tab.", error);
     }
   }
 
@@ -386,6 +414,19 @@ class HomePage extends React.Component {
                           </div>
                           <CaretRightSVG />
                         </Link>
+                        {resource.metadata.uris?.[0] && (
+                          <button
+                            type="button"
+                            className="launch-resource-button"
+                            onClick={(event) => this.handleLaunchResourceClick(event, resource)}
+                            title={this.props.t("Open in a new tab")}
+                          >
+                            <GoSVG />
+                            <span className="visually-hidden">
+                              <Trans>Open in a new tab</Trans>
+                            </span>
+                          </button>
+                        )}
                       </li>
                     ))}
                 </React.Fragment>

--- a/src/react-quickaccess/components/HomePage/HomePage.js
+++ b/src/react-quickaccess/components/HomePage/HomePage.js
@@ -35,6 +35,8 @@ import DisplayResourceUrisBadge from "../../../react-extension/components/Resour
 import CanSuggestService from "../../../shared/services/canSuggestService/canSuggestService";
 import CaretRightSVG from "../../../img/svg/caret_right.svg";
 import GoSVG from "../../../img/svg/go.svg";
+import sanitizeUrl, { urlProtocols } from "../../../react-extension/lib/Sanitize/sanitizeUrl";
+import { resourceLinkAuthorizedProtocols } from "../../../react-extension/contexts/ResourceWorkspaceContext";
 import FilterSVG from "../../../img/svg/filter.svg";
 import UsersSVG from "../../../img/svg/users.svg";
 import TagV2SVG from "../../../img/svg/tag_v2.svg";
@@ -70,6 +72,8 @@ class HomePage extends React.Component {
     return {
       activeTabUrl: null,
       usingOnThisTab: false,
+      autofillOnLaunch: false, // Whether clicking the launch action should navigate then autofill.
+      launchingResource: false, // True while a launch-with-autofill request is in progress.
     };
   }
 
@@ -94,6 +98,17 @@ class HomePage extends React.Component {
     this.props.context.focusSearch();
 
     this.loadActiveTabUrl();
+    this.loadAutofillSettings();
+
+    // Enable arrow-key navigation through the suggested/browse/filter list.
+    document.addEventListener("keydown", this.handleListKeyDown);
+  }
+
+  /**
+   * ComponentWillUnmount hook. Remove the keyboard navigation listener.
+   */
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.handleListKeyDown);
   }
 
   /**
@@ -102,6 +117,48 @@ class HomePage extends React.Component {
   initEventHandlers() {
     this.handleUseOnThisTabClick = this.handleUseOnThisTabClick.bind(this);
     this.handleLaunchResourceClick = this.handleLaunchResourceClick.bind(this);
+    this.handleListKeyDown = this.handleListKeyDown.bind(this);
+  }
+
+  /**
+   * Loads the autofill on launch settings into the state.
+   * Falls back to autofill disabled (the plain open-in-new-tab behaviour) on error.
+   * @returns {Promise<void>}
+   */
+  async loadAutofillSettings() {
+    try {
+      const settings = await this.props.context.port.request("passbolt.autofill-settings.get");
+      this.setState({ autofillOnLaunch: Boolean(settings?.autofillOnLaunch) });
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  /**
+   * Handles the click on a search-result row's launch action when autofill on launch is enabled.
+   * Asks the background to navigate to the resource URI and autofill the login form (never submits),
+   * then closes the quickaccess window.
+   *
+   * The background work (navigate, wait for the page, passphrase prompt, decrypt, fill) runs in the
+   * service worker independently of this popup, and the passphrase prompt opens its own quickaccess
+   * window. We therefore dispatch the request and close immediately rather than awaiting the full
+   * chain, awaiting would keep this popup open until navigation steals focus and tears it down,
+   * leaving the awaited response unresolved.
+   * @param {Event} event
+   * @param {Object} resource
+   * @returns {void}
+   */
+  handleLaunchResourceClick(event, resource) {
+    event.preventDefault();
+    if (this.state.launchingResource) {
+      return;
+    }
+    this.setState({ launchingResource: true });
+    // Fire-and-forget: do not await; the controller continues in the background after the popup closes.
+    this.props.context.port
+      .request("passbolt.quickaccess.launch-resource", resource.id, this.props.context.getOpenerTabId())
+      .catch((error) => console.error(error));
+    this.props.context.closeWindow();
   }
 
   /**
@@ -118,6 +175,56 @@ class HomePage extends React.Component {
     } catch (error) {
       console.error(error);
     }
+  }
+
+  /**
+   * Arrow-key navigation through the result list (suggested, browse, and filter entries).
+   * ArrowDown/ArrowUp move focus between the primary control of each row; ArrowUp from the first
+   * row returns focus to the search field. Enter activates the focused control natively, and Tab
+   * still reaches per-row actions (e.g. the launch button).
+   * @param {KeyboardEvent} event
+   */
+  handleListKeyDown(event) {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+      return;
+    }
+    const items = Array.from(
+      document.querySelectorAll(
+        ".index-list li.suggested-resource-entry > button, " +
+          ".index-list li.browse-resource-entry > a:not(.launch-resource-button), " +
+          ".index-list li.filter-entry > a",
+      ),
+    );
+    if (items.length === 0) {
+      return;
+    }
+    const currentIndex = items.indexOf(document.activeElement);
+    if (event.key === "ArrowDown") {
+      const next = currentIndex === -1 ? items[0] : items[Math.min(currentIndex + 1, items.length - 1)];
+      this.focusListItem(next);
+      event.preventDefault();
+    } else if (currentIndex > 0) {
+      this.focusListItem(items[currentIndex - 1]);
+      event.preventDefault();
+    } else if (currentIndex === 0) {
+      const searchInput = document.querySelector("input[name='search']");
+      if (searchInput) {
+        searchInput.focus();
+        event.preventDefault();
+      }
+    }
+  }
+
+  /**
+   * Focus a result-list item and scroll it into view.
+   * @param {HTMLElement} item
+   */
+  focusListItem(item) {
+    if (!item) {
+      return;
+    }
+    item.focus();
+    item.scrollIntoView?.({ block: "nearest" });
   }
 
   /**
@@ -200,22 +307,11 @@ class HomePage extends React.Component {
    * @param {Object} resource
    * @returns {Promise<void>}
    */
-  async handleLaunchResourceClick(event, resource) {
-    // The button is a sibling of the row link; prevent the row navigation.
-    event.preventDefault();
-    event.stopPropagation();
-
-    const uri = resource.metadata?.uris?.[0];
-    if (!uri) {
-      return;
-    }
-
-    try {
-      await this.props.context.port.request("passbolt.tabs.open-resource-uri", uri);
-      await this.props.context.closeWindow();
-    } catch (error) {
-      console.error("Unable to open the resource URL in a new tab.", error);
-    }
+  sanitizeResourceUrl(url) {
+    return sanitizeUrl(url, {
+      whiteListedProtocols: resourceLinkAuthorizedProtocols,
+      defaultProtocol: urlProtocols.HTTPS,
+    });
   }
 
   /**
@@ -414,19 +510,35 @@ class HomePage extends React.Component {
                           </div>
                           <CaretRightSVG />
                         </Link>
-                        {resource.metadata.uris?.[0] && (
-                          <button
-                            type="button"
-                            className="launch-resource-button"
-                            onClick={(event) => this.handleLaunchResourceClick(event, resource)}
-                            title={this.props.t("Open in a new tab")}
-                          >
-                            <GoSVG />
-                            <span className="visually-hidden">
-                              <Trans>Open in a new tab</Trans>
-                            </span>
-                          </button>
-                        )}
+                        {this.sanitizeResourceUrl(resource.metadata.uris?.[0]) &&
+                          (this.state.autofillOnLaunch ? (
+                            <button
+                              type="button"
+                              className="launch-resource-button"
+                              disabled={this.state.launchingResource}
+                              onClick={(event) => this.handleLaunchResourceClick(event, resource)}
+                              title={this.props.t("Open and autofill")}
+                            >
+                              <GoSVG />
+                              <span className="visually-hidden">
+                                <Trans>Open and autofill</Trans>
+                              </span>
+                            </button>
+                          ) : (
+                            <a
+                              href={this.sanitizeResourceUrl(resource.metadata.uris?.[0])}
+                              role="button"
+                              className="launch-resource-button"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              title={this.props.t("Open in a new tab")}
+                            >
+                              <GoSVG />
+                              <span className="visually-hidden">
+                                <Trans>Open in a new tab</Trans>
+                              </span>
+                            </a>
+                          ))}
                       </li>
                     ))}
                 </React.Fragment>

--- a/src/react-quickaccess/components/HomePage/HomePage.test.js
+++ b/src/react-quickaccess/components/HomePage/HomePage.test.js
@@ -222,7 +222,7 @@ describe("HomePage", () => {
 
       expect(page.browsedResources.length).toStrictEqual(1);
       expect(page.browsedResources[0].textContent).toStrictEqual(
-        `${expectedResource.metadata.name} (${expectedResource.metadata.username})${expectedResource.metadata.uris[0]}`,
+        `${expectedResource.metadata.name} (${expectedResource.metadata.username})${expectedResource.metadata.uris[0]}Open in a new tab`,
       );
     });
 


### PR DESCRIPTION
## Summary

Quickaccess UI enhancements, additive and unobtrusive:

1. **Launch control in search results** — a per-row action to open a resource's saved URL directly from the search results (the "launch" affordance other managers offer), instead of having to drill into the detail view.
2. **Keyboard navigation** — arrow-key roving focus through the suggested / browse / filter rows with a visible focus ring; ArrowUp from the first row returns focus to the search field. Pure accessibility/UX.
3. **Autofill-on-launch button** — when the extension's device-local "autofill on launch" setting is enabled, the launch control navigates and asks the background to autofill the form (**never submits**); when disabled it opens the URL (reusing a blank tab). URLs are sanitised before use.

The controller, setting, and options page are in a companion `passbolt_browser_extension` PR.

## Notes

Keyboard navigation and the launch control are independent improvements; the autofill behaviour is gated entirely by the extension setting and the extension's origin checks (credential filled, never submitted, only on an origin match). Opened as a **draft** for feedback. Companion extension PR: `passbolt/passbolt_browser_extension` (linked once both are open).
