### PR TITLE
Let websites opt out of the in-form integration with a data-passbolt-ignore attribute

### DIFF
--- a/src/react-web-integration/lib/InForm/InFormCallToActionField.js
+++ b/src/react-web-integration/lib/InForm/InFormCallToActionField.js
@@ -15,6 +15,7 @@
 import { v4 as uuidv4 } from "uuid";
 import DomUtils from "../Dom/DomUtils";
 import browser from "webextension-polyfill";
+import { IN_FORM_IGNORE_ATTRIBUTE } from "./InFormFieldSelector";
 
 /**
  * An InFormCallToActionField is represented by a DOM element identified as an username field and to which
@@ -39,7 +40,21 @@ class InFormCallToActionField {
 
     const iframesFields = InFormCallToActionField.findAllInIframes(selector);
     const shadowDomFields = InFormCallToActionField.findAllInShadowDom(selector);
-    return domFields.concat(iframesFields).concat(shadowDomFields);
+    return domFields
+      .concat(iframesFields)
+      .concat(shadowDomFields)
+      .filter((field) => !InFormCallToActionField.isOptedOut(field));
+  }
+
+  /**
+   * Whether a field has opted out of the in-form integration, either directly or through one of its
+   * ancestors carrying the `data-passbolt-ignore` attribute. Websites can use it to prevent passbolt
+   * from attaching to a specific field, form or section.
+   * @param {Element} field The DOM element
+   * @return {boolean}
+   */
+  static isOptedOut(field) {
+    return field.closest(`[${IN_FORM_IGNORE_ATTRIBUTE}]`) !== null;
   }
 
   /**

--- a/src/react-web-integration/lib/InForm/InFormCredentialsFormField.js
+++ b/src/react-web-integration/lib/InForm/InFormCredentialsFormField.js
@@ -29,7 +29,7 @@ class InFormCredentialsFormField {
   static findAll() {
     const domFields = Array.from(document.querySelectorAll("form"));
     const iframesFields = InFormCallToActionField.findAllInIframes();
-    return domFields.concat(iframesFields);
+    return domFields.concat(iframesFields).filter((field) => !InFormCallToActionField.isOptedOut(field));
   }
 
   /**

--- a/src/react-web-integration/lib/InForm/InFormFieldOptOut.test.js
+++ b/src/react-web-integration/lib/InForm/InFormFieldOptOut.test.js
@@ -1,0 +1,105 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.7.0
+ */
+
+/**
+ * Unit tests on the `data-passbolt-ignore` opt-out attribute, which lets a website exclude a field,
+ * a form or a whole section from the passbolt in-form integration.
+ */
+
+import InFormCallToActionField from "./InFormCallToActionField";
+import InFormCredentialsFormField from "./InFormCredentialsFormField";
+import InFormFieldSelector from "./InFormFieldSelector";
+
+describe("In-form field opt-out (data-passbolt-ignore)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  describe("InFormCallToActionField::findAll", () => {
+    it("detects a username field when it is not opted out", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<input type="text" name="username">`;
+      const fields = InFormCallToActionField.findAll(InFormFieldSelector.USERNAME_FIELD_SELECTOR);
+      expect(fields).toHaveLength(1);
+    });
+
+    it("excludes a field carrying the data-passbolt-ignore attribute", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<input type="text" name="username" data-passbolt-ignore>`;
+      const fields = InFormCallToActionField.findAll(InFormFieldSelector.USERNAME_FIELD_SELECTOR);
+      expect(fields).toHaveLength(0);
+    });
+
+    it("excludes a password field nested in a container carrying the data-passbolt-ignore attribute", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<div data-passbolt-ignore><input type="password" name="password"></div>`;
+      const fields = InFormCallToActionField.findAll(InFormFieldSelector.PASSWORD_FIELD_SELECTOR);
+      expect(fields).toHaveLength(0);
+    });
+
+    it("only excludes the opted-out field and keeps the others", () => {
+      expect.assertions(2);
+      document.body.innerHTML = `
+        <input type="text" name="username" id="kept">
+        <input type="text" name="email" id="ignored" data-passbolt-ignore>
+      `;
+      const fields = InFormCallToActionField.findAll(InFormFieldSelector.USERNAME_FIELD_SELECTOR);
+      expect(fields).toHaveLength(1);
+      expect(fields[0].id).toBe("kept");
+    });
+  });
+
+  describe("InFormCredentialsFormField::findAll", () => {
+    it("detects a form when it is not opted out", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<form><input type="text" name="username"><input type="password" name="password"></form>`;
+      expect(InFormCredentialsFormField.findAll()).toHaveLength(1);
+    });
+
+    it("excludes a form carrying the data-passbolt-ignore attribute from auto-save detection", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<form data-passbolt-ignore><input type="text" name="username"><input type="password" name="password"></form>`;
+      expect(InFormCredentialsFormField.findAll()).toHaveLength(0);
+    });
+
+    it("excludes a form nested in a container carrying the data-passbolt-ignore attribute", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<section data-passbolt-ignore><form><input type="password" name="password"></form></section>`;
+      expect(InFormCredentialsFormField.findAll()).toHaveLength(0);
+    });
+  });
+
+  describe("InFormCallToActionField::isOptedOut", () => {
+    it("returns false when neither the field nor its ancestors carry the attribute", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<div><input type="text" name="username"></div>`;
+      const field = document.querySelector("input");
+      expect(InFormCallToActionField.isOptedOut(field)).toBe(false);
+    });
+
+    it("returns true when the field itself carries the attribute", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<input type="text" name="username" data-passbolt-ignore>`;
+      const field = document.querySelector("input");
+      expect(InFormCallToActionField.isOptedOut(field)).toBe(true);
+    });
+
+    it("returns true when an ancestor carries the attribute", () => {
+      expect.assertions(1);
+      document.body.innerHTML = `<div data-passbolt-ignore><span><input type="text" name="username"></span></div>`;
+      const field = document.querySelector("input");
+      expect(InFormCallToActionField.isOptedOut(field)).toBe(true);
+    });
+  });
+});

--- a/src/react-web-integration/lib/InForm/InFormFieldSelector.js
+++ b/src/react-web-integration/lib/InForm/InFormFieldSelector.js
@@ -15,6 +15,17 @@
 import { UsernameFieldSelectorException } from "./InFormFieldSelectorException";
 
 /**
+ * Attribute a website can set on a field - or on any of its ancestors - to opt it out of the
+ * passbolt in-form integration (call-to-action icon, in-form menu and auto-save).
+ *
+ * This mirrors the opt-out attributes offered by other password managers, e.g.
+ * 1Password (`data-1p-ignore`), Bitwarden (`data-bwignore`) and LastPass (`data-lpignore`).
+ *
+ * @type {string}
+ */
+export const IN_FORM_IGNORE_ATTRIBUTE = "data-passbolt-ignore";
+
+/**
  * All the possible in-form fields DOM selectors
  */
 export default {


### PR DESCRIPTION
## Let websites opt out of the in-form integration with `data-passbolt-ignore`

This pull request is a (multiple allowed):

* [ ] bug fix
* [ ] change of existing behavior
* [x] new feature

Checklist
* [x] User stories are present (given, when, then format)
* [x] Unit tests are passing
* [ ] Selenium tests are passing
* [x] Check style is not triggering new error or warning

### What you did

Today there is **no client-side way for a website to tell passbolt to leave one of its inputs alone**. Field detection in `InFormFieldSelector` is purely heuristic (substring matches on `name`/`id`/`class`/`autocomplete`/`placeholder`, plus `type=password`/`type=email`). When those heuristics fire on an input that has nothing to do with credentials, the call-to-action icon appears on it, overlaps the field, and can intercept clicks. The only existing switch is the server-wide `PASSBOLT_PLUGINS_IN_FORM_INTEGRATION_ENABLED` env var (`SiteSettings.canIUse("inFormIntegration")`), which is all-or-nothing and only the server administrator can change.

This is a recurring pain point reported by the community, e.g.:
- ["As a user I should be able to disable the in-form menu in the settings" (PB-27841)](https://community.passbolt.com/t/pb-27841-as-a-user-i-should-be-able-to-disable-the-in-form-menu-in-the-settings/4752) — *"it appears on inputs that are not connected to passwords at all and it is annoying"*, *"on most OTP forms I now have 6 Passbolt icons obscuring the one digit wide field"*.

Every other major password manager already gives **web developers an attribute-level opt-out** so they can suppress the integration on specific fields/forms:

| Password manager | Opt-out attribute |
| --- | --- |
| 1Password | `data-1p-ignore` |
| Bitwarden | `data-bwignore` |
| LastPass | `data-lpignore="true"` |
| Dashlane | `data-form-type="other"` |

This PR adds the equivalent for passbolt: **`data-passbolt-ignore`**. Setting it on a field — or on any ancestor (a `<form>`, a wrapper `<div>`, a whole section) — excludes every descendant input from detection.

```html
<!-- excluded individually -->
<input type="text" name="search-user" data-passbolt-ignore>

<!-- the whole form is excluded (no icon, no in-form menu, no auto-save) -->
<form data-passbolt-ignore> ... </form>
```

#### How

The opt-out is enforced **centrally**, in the two detection entry points, rather than by editing every selector:

- `InFormCallToActionField.findAll()` — filters out opted-out username / password / OTP fields (including those found in iframes and shadow DOM).
- `InFormCredentialsFormField.findAll()` — filters out opted-out forms so auto-save is not proposed for them.
- A new `InFormCallToActionField.isOptedOut(field)` helper uses `Element.closest('[data-passbolt-ignore]')`, which is why marking an ancestor cascades to all descendants.
- The attribute name is exported once as `IN_FORM_IGNORE_ATTRIBUTE` from `InFormFieldSelector.js`.

#### User stories

- **Given** a website that renders an input matching passbolt's username/password heuristics, **when** the developer adds `data-passbolt-ignore` to that input, **then** the call-to-action icon and in-form menu are not attached to it.
- **Given** a `<form>` (or any container) carrying `data-passbolt-ignore`, **when** the page loads or mutates, **then** none of its fields are detected and passbolt does not propose to auto-save it.
- **Given** an input that does **not** carry the attribute (directly or via an ancestor), **when** the page is scanned, **then** detection behaves exactly as before (no regression).

#### Tests

Added `InFormFieldOptOut.test.js` (11 cases) covering field-level, container-level and form-level opt-out, the "keep the others" case, and the `isOptedOut` helper. The existing `InformManager` suite still passes (82 tests green total), and `eslint --max-warnings 0` is clean on the changed files.

#### Notes

- Fully backwards compatible: behavior only changes when the new attribute is present.
- This is intentionally the *developer-facing* half of the problem. The *user-facing* request in PB-27841 (a setting to disable the in-form menu for the logged-in user) is complementary and proposed separately.
